### PR TITLE
Show errors login

### DIFF
--- a/src/app/authentication/signin/signin.component.html
+++ b/src/app/authentication/signin/signin.component.html
@@ -9,7 +9,11 @@
                 </mat-toolbar>
                 <mat-card-content>
                     <form name="Form">
-                        <br/>
+											  <br *ngIf="show" />
+												<div *ngIf="show" class="alert alert-warning" role="alert">
+													{{errorMessage}}
+												</div>	
+												<br/>
                         <mat-form-field class="md-block">
                             <input type="text" matInput placeholder="Email" required="" [(ngModel)]="credentials.username" name="username"/>
                         </mat-form-field>

--- a/src/app/authentication/signin/signin.component.html
+++ b/src/app/authentication/signin/signin.component.html
@@ -22,7 +22,6 @@
                             <input type="password" matInput placeholder="Password" required="" [(ngModel)]="credentials.password" name="password"/>
                         </mat-form-field>
                         <div class="md-block">
-                            <button mat-raised-button routerLink="../signup">Register</button>
                             <button mat-raised-button (click)="signin()" color="primary">Login</button>
                         </div>
                     </form>

--- a/src/app/authentication/signin/signin.component.ts
+++ b/src/app/authentication/signin/signin.component.ts
@@ -10,6 +10,7 @@ import {AuthenticationService} from '../authentication.service';
 
 export class SigninComponent {
   errorMessage: string;
+  show: boolean;
   credentials: any = {};
 
   constructor (private _authenticationService: AuthenticationService, private _router: Router) {
@@ -18,5 +19,6 @@ export class SigninComponent {
   signin() {
     this._authenticationService.signin(this.credentials).subscribe(result  => this._router.navigate(['/']), 
                                                                    error =>  this.errorMessage = error );
+    this.show = true;
   }
 }


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Shows users an error if there is a problem with their login credentials: Wrong user/password or empty fields.

When the user hits the enter key to login, it would use the register button instead.

* **What is the current behavior?** (You can also link to an open issue here)

Doesn't let the user know anything. Takes the user to the wrong form.

* **What is the new behavior (if this is a feature change)?**

Adds a hidden dialogue box to let the user know the error.
Removed register button (no longer needed according to design specs).

* **Other information**:
